### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/openhealthcare/opal-ideas.png?label=ready&title=Ready)](https://waffle.io/openhealthcare/opal-ideas)
 # OPAL Ideas, Roadmap, Wishlist
 
 The issue tracker for this repository outlines potential ideas for OPAL development. 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/openhealthcare/opal-ideas

This was requested by a real person (user GabPoll) on waffle.io, we're not trying to spam you.
